### PR TITLE
issue #8 links new tab

### DIFF
--- a/_src/templates/profile-card.html
+++ b/_src/templates/profile-card.html
@@ -33,12 +33,12 @@
                 </a>
               </li>
               <li class="media-icon">
-                <a href="" alt="Linkedin" title="Go to Linkedin" class="js-linkedin-icon">
+                <a href="" alt="Linkedin" title="Go to Linkedin" class="js-linkedin-icon" target="_blank">
                   <div class="fab fa-linkedin-in" style="color:#114e4e"></div>
                 </a>
               </li>
               <li class="media-icon">
-                <a class="js-github-icon" class="" href="" alt="Github" title="Go to Github">
+                <a class="js-github-icon" class="" href="" alt="Github" title="Go to Github" target="_blank">
                   <div class="fab fa-github-alt" style="color:#114e4e"></div>
                 </a>
               </li>


### PR DESCRIPTION
Just added `target="_blank"` to Linkedin and Github icons in order to open the pages in a new tab.